### PR TITLE
Adds full filepath for webcam images

### DIFF
--- a/bumblebee/app.py
+++ b/bumblebee/app.py
@@ -97,7 +97,8 @@ class BumbleBee():
                     try:
                         if camera_control.takePicture(camera['device'], watermark=None, output=outfile):
                             self.lastImageTime = time.time()
-                            camera_files.append(outfile)
+                            fullImgPath = hive.getImageDirectory(outfile)
+                            camera_files.append(fullImgPath)
                     except Exception as ex:
                         self.log.exception(ex)
 

--- a/bumblebee/camera_control.py
+++ b/bumblebee/camera_control.py
@@ -56,8 +56,8 @@ def takePicture(device, watermark=None, output="webcam.jpg", brightness=50, cont
                 imagesnap = os.path.dirname(os.path.realpath(__file__)) + os.sep + "imagesnap"
                 command = "%s -q -d '%s' -w 2.0 '%s' && " \
                           "sips --resampleWidth 640" \
-                          "--padToHeightWidth 480 640" \
-                          "--padColor FFFFFF -s formatOptions 60%% '%s' 2>/dev/null" % (
+                          " --padToHeightWidth 480 640" \
+                          " --padColor FFFFFF -s formatOptions 60%% '%s' 2>/dev/null" % (
                               imagesnap,
                               device,
                               output,
@@ -79,10 +79,10 @@ def takePicture(device, watermark=None, output="webcam.jpg", brightness=50, cont
                         return False
                 else:
                     command = "exec /usr/bin/fswebcam" \
-                              "-q --jpeg 60 -d '%s'" \
-                              "-r 640x480 --title '%s'" \
-                              "--set brightness=%s%%" \
-                              "--set contrast=%s%% '%s'" % (
+                              " -q --jpeg 60 -d '%s'" \
+                              " -r 640x480 --title '%s'" \
+                              " --set brightness=%s%%" \
+                              " --set contrast=%s%% '%s'" % (
                                   device,
                                   watermark,
                                   brightness,

--- a/bumblebee/workerbee.py
+++ b/bumblebee/workerbee.py
@@ -139,7 +139,8 @@ class WorkerBee():
                 if time.time() - lastWebcamUpdate > 60:
                     outputName = "bot-%s.jpg" % self.data['id']
                     if self.takePicture(outputName):
-                        self.api.webcamUpdate(outputName, bot_id=self.data['id'])
+                        fullImgPath = hive.getImageDirectory(outputName)
+                        self.api.webcamUpdate(fullImgPath, bot_id=self.data['id'])
                     lastWebcamUpdate = time.time()
 
                 time.sleep(self.sleepTime)  # sleep for a bit to not hog resources

--- a/bumblebee/workerbee.py
+++ b/bumblebee/workerbee.py
@@ -430,7 +430,8 @@ class WorkerBee():
         outputName = "bot-%s.jpg" % self.data['id']
 
         if self.takePicture(outputName):
-            self.api.webcamUpdate(outputName,
+            fullImgPath = hive.getImageDirectory(outputName)
+            self.api.webcamUpdate(fullImgPath,
                                   job_id=self.data['job']['id'],
                                   progress="%0.5f" % float(latest),
                                   temps=temps)


### PR DESCRIPTION
I had issues with the webcam images not found (the open function in the api fails as the images are in "/usr/local/lib/python2.7/dist-packages/bumblebee/images/" and the open function is given only the file name). I fixed this on my system by using the full path to the image.

Please see if the change makes any sense to you as I only tested the pip version on ubuntu 14.04 (as running the git version directly proved to be slightly challenging).

Some errors still remain though, as for example the cameracontroll seems to check for the existence of the output, but that fails, resulting on errors like: 
[2015-01-13 11:12:39,157] INFO: Webcam Command: exec /usr/bin/fswebcam -q --jpeg 60 -d '/dev/video1' -r 640x480 --title 'mf2 :: BotQueue.com' --set brightness=50% --set contrast=50% '/usr/local/lib/python2.7/dist-packages/bumblebee/images/bot-590.jpg'
[2015-01-13 11:12:39,668] ERROR: Webcam: stat: No such file or directory
[2015-01-13 11:12:39,668] ERROR: Webcam: 
[2015-01-13 11:12:39,668] ERROR: Errors detected.  Bailing.
